### PR TITLE
Setup Tailwind Colors and Fonts

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -20,10 +20,15 @@
     --input: 220 13% 91%;
  
     --primary: 220.9 39.3% 11%;
-    --primary-foreground: 210 20% 98%;
+    --primary-blue: 203 97% 14%;
+    --primary-red: 359 100% 23%;
  
     --secondary: 220 14.3% 95.9%;
-    --secondary-foreground: 220.9 39.3% 11%;
+    --secondary-blue: 199 54% 37%;
+    --secondary-red: 357 68% 45%;
+    --secondary-light-blue: 206 40% 56%;
+
+    --cream: 43 57% 88%;
  
     --accent: 220 14.3% 95.9%;
     --accent-foreground: 220.9 39.3% 11%;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,64 +1,70 @@
-import { fontFamily } from "tailwindcss/defaultTheme";
-import type { Config } from "tailwindcss";
+import { fontFamily } from 'tailwindcss/defaultTheme'
+import type { Config } from 'tailwindcss'
 
 const config: Config = {
-	darkMode: ["class"],
-	content: ["./src/**/*.{html,js,svelte,ts}"],
-	safelist: ["dark"],
-	theme: {
-		container: {
-			center: true,
-			padding: "2rem",
-			screens: {
-				"2xl": "1400px"
-			}
-		},
-		extend: {
-			colors: {
-				border: "hsl(var(--border) / <alpha-value>)",
-				input: "hsl(var(--input) / <alpha-value>)",
-				ring: "hsl(var(--ring) / <alpha-value>)",
-				background: "hsl(var(--background) / <alpha-value>)",
-				foreground: "hsl(var(--foreground) / <alpha-value>)",
-				primary: {
-					DEFAULT: "hsl(var(--primary) / <alpha-value>)",
-					foreground: "hsl(var(--primary-foreground) / <alpha-value>)"
-				},
-				secondary: {
-					DEFAULT: "hsl(var(--secondary) / <alpha-value>)",
-					foreground: "hsl(var(--secondary-foreground) / <alpha-value>)"
-				},
-				destructive: {
-					DEFAULT: "hsl(var(--destructive) / <alpha-value>)",
-					foreground: "hsl(var(--destructive-foreground) / <alpha-value>)"
-				},
-				muted: {
-					DEFAULT: "hsl(var(--muted) / <alpha-value>)",
-					foreground: "hsl(var(--muted-foreground) / <alpha-value>)"
-				},
-				accent: {
-					DEFAULT: "hsl(var(--accent) / <alpha-value>)",
-					foreground: "hsl(var(--accent-foreground) / <alpha-value>)"
-				},
-				popover: {
-					DEFAULT: "hsl(var(--popover) / <alpha-value>)",
-					foreground: "hsl(var(--popover-foreground) / <alpha-value>)"
-				},
-				card: {
-					DEFAULT: "hsl(var(--card) / <alpha-value>)",
-					foreground: "hsl(var(--card-foreground) / <alpha-value>)"
-				}
-			},
-			borderRadius: {
-				lg: "var(--radius)",
-				md: "calc(var(--radius) - 2px)",
-				sm: "calc(var(--radius) - 4px)"
-			},
-			fontFamily: {
-				sans: [...fontFamily.sans]
-			}
-		}
-	},
-};
+  darkMode: ['class'],
+  content: ['./src/**/*.{html,js,svelte,ts}'],
+  safelist: ['dark'],
+  theme: {
+    container: {
+      center: true,
+      padding: '2rem',
+      screens: {
+        '2xl': '1400px',
+      },
+    },
+    extend: {
+      colors: {
+        border: 'hsl(var(--border) / <alpha-value>)',
+        input: 'hsl(var(--input) / <alpha-value>)',
+        ring: 'hsl(var(--ring) / <alpha-value>)',
+        background: 'hsl(var(--background) / <alpha-value>)',
+        foreground: 'hsl(var(--foreground) / <alpha-value>)',
+        primary: {
+          DEFAULT: 'hsl(var(--primary) / <alpha-value>)',
+          blue: 'hsl(var(--primary-blue) / <alpha-value>)',
+          red: 'hsl(var(--primary-red) / <alpha-value>)',
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary) / <alpha-value>)',
+          blue: 'hsl(var(--secondary-blue) / <alpha-value>)',
+          red: 'hsl(var(--secondary-red) / <alpha-value>)',
+          lightBlue: 'hsl(var(--secondary-light-blue) / <alpha-value>)',
+        },
+        cream: 'hsl(var(--cream) / <alpha-value>)',
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive) / <alpha-value>)',
+          foreground: 'hsl(var(--destructive-foreground) / <alpha-value>)',
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted) / <alpha-value>)',
+          foreground: 'hsl(var(--muted-foreground) / <alpha-value>)',
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent) / <alpha-value>)',
+          foreground: 'hsl(var(--accent-foreground) / <alpha-value>)',
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover) / <alpha-value>)',
+          foreground: 'hsl(var(--popover-foreground) / <alpha-value>)',
+        },
+        card: {
+          DEFAULT: 'hsl(var(--card) / <alpha-value>)',
+          foreground: 'hsl(var(--card-foreground) / <alpha-value>)',
+        },
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)',
+      },
+      fontFamily: {
+        sans: [...fontFamily.sans],
+        heading: ['"Libre Baskerville"'],
+        body: ['"Muli Regular'],
+      },
+    },
+  },
+}
 
-export default config;
+export default config


### PR DESCRIPTION
# Setup Tailwind Colors and Fonts

Setup variables with hsl value and Tailwind classes for colors listed in figma.

## Variables

 - --primary-blue: 203 97% 14%; (#012D48)
 - --primary-red: 359 100% 23%; (#740001)
 - --secondary-blue: 199 54% 37%; (#2B7292)
 - --secondary-red: 357 68% 45%; (#C2252E)
 - --secondary-light-blue: 206 40% 56%; (#6195BC)
 - --cream: 43 57% 88%; (#F2E8CF)

## Tailwind Class

### Colors

 - primary-blue (#012D48)
 - primary-red (#740001)
 - secondary-blue (#2B7292)
 - secondary-red (#C2252E)
 - secondary-lightBlue (#6195BC)
 - cream (#F2E8CF)

### Fonts

 - heading (Libre Baskerville)
 - body (Muli Regular)
